### PR TITLE
Added rudimentary http error handling

### DIFF
--- a/services/graphql-server/directives/common/http.go
+++ b/services/graphql-server/directives/common/http.go
@@ -176,6 +176,13 @@ func doHTTP(request *http.Request, client httpClient) (interface{}, error) {
 		return nil, err
 	}
 
+	if response.StatusCode == 404 {
+		return nil, nil
+	}
+	if response.StatusCode >= 400 {
+		return nil, fmt.Errorf("Got HTTP %v from %v: %v", response.StatusCode, request.Host, string(buffer))
+	}
+
 	var result interface{}
 
 	err = json.Unmarshal(buffer, &result)

--- a/services/graphql-server/directives/common/http.go
+++ b/services/graphql-server/directives/common/http.go
@@ -180,7 +180,7 @@ func doHTTP(request *http.Request, client httpClient) (interface{}, error) {
 		return nil, nil
 	}
 	if response.StatusCode >= 400 {
-		return nil, fmt.Errorf("Got HTTP %v from %v: %v", response.StatusCode, request.Host, string(buffer))
+		return nil, fmt.Errorf("HTTP Error. StatusCode=%v, Host=%v, ResponseBody=%v", response.StatusCode, request.Host, string(buffer))
 	}
 
 	var result interface{}


### PR DESCRIPTION
Related: #64 
So this change will make us treat 404's as nulls, and all other >=400 http codes will be returned as errors.
I'm not sure about the fact that we're leaking the internal service call in case of an error, but I don't really see how we can avoid it.