### PR TITLE
Run HTTP Requests Concurrently

### DIFF
--- a/services/graphql-server/directives/common/http.go
+++ b/services/graphql-server/directives/common/http.go
@@ -147,6 +147,8 @@ func createHTTPRequest(p httpParams, rp graphql.ResolveParams) (*http.Request, e
 		return nil, err
 	}
 
+	request = request.WithContext(rp.Context)
+
 	for _, h := range p.headers {
 		request.Header.Set(h.name, replace(h.value, args, input, source))
 	}

--- a/services/graphql-server/directives/common/http.go
+++ b/services/graphql-server/directives/common/http.go
@@ -44,7 +44,7 @@ var httpMiddleware = middlewares.DirectiveDefinition{
 	MiddlewareFactory: func(f *ast.FieldDefinition, d *ast.Directive) middlewares.Middleware {
 		params := parseHTTPParams(d)
 		client := createHTTPClient(params.timeout)
-		return middlewares.Leaf(func(rp graphql.ResolveParams) (interface{}, error) {
+		return middlewares.ConcurrentLeaf(func(rp graphql.ResolveParams) (interface{}, error) {
 			request, err := createHTTPRequest(params, rp)
 			if err != nil {
 				return nil, err

--- a/services/graphql-server/directives/middlewares/concurrentLeaf.go
+++ b/services/graphql-server/directives/middlewares/concurrentLeaf.go
@@ -1,0 +1,31 @@
+package middlewares
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+type ConcurrentLeaf func(graphql.ResolveParams) (interface{}, error)
+
+func (cl ConcurrentLeaf) Wrap(next Resolver) Resolver {
+	type result struct {
+		data interface{}
+		err  error
+	}
+
+	return func(g graphql.ResolveParams) (interface{}, error) {
+		ch := make(chan *result, 1)
+
+		go func() {
+			defer close(ch)
+
+			data, err := cl(g)
+
+			ch <- &result{data: data, err: err}
+		}()
+
+		return func() (interface{}, error) {
+			res := <-ch
+			return res.data, res.err
+		}, nil
+	}
+}


### PR DESCRIPTION
* Run http requests concurrently
* Propagate http cancellation to http directive so requests will be aborted properly
[Concurrency documentation](https://github.com/graphql-go/graphql/blob/master/examples/concurrent-resolvers/main.go)