### PR TITLE
Added "forward auth header" as an authentication type

### DIFF
--- a/remote-sources/kubernetes/src/crd/Upstream.yaml
+++ b/remote-sources/kubernetes/src/crd/Upstream.yaml
@@ -36,6 +36,7 @@ spec:
                   enum:
                     - oauth2/client_credentials
                     - activedirectory/client_credentials
+                    - forward_auth_header
                 authority:
                   type: string
                 scope:

--- a/services/graphql-server/directives/common/http.go
+++ b/services/graphql-server/directives/common/http.go
@@ -161,7 +161,7 @@ func createHTTPRequest(s server.ServerContext, p httpParams, rp graphql.ResolveP
 
 	ep, ok := s.Upstream(request.URL.Host)
 	if ok {
-		ep.ApplyUpstream(request)
+		ep.ApplyUpstream(rp.Context, request)
 	}
 
 	return request, nil

--- a/services/graphql-server/extensions/upstreams/authentication/consts.go
+++ b/services/graphql-server/extensions/upstreams/authentication/consts.go
@@ -1,0 +1,11 @@
+package authentication
+
+const (
+	authTypeForwardHeader   = "forward_auth_header"
+	authTypeOAuth2          = "oauth2/client_credentials"
+	authTypeActiveDirectory = "activedirectory/client_credentials"
+)
+
+var (
+	authTypes = []string{authTypeForwardHeader, authTypeOAuth2, authTypeActiveDirectory}
+)

--- a/services/graphql-server/extensions/upstreams/authentication/consts.go
+++ b/services/graphql-server/extensions/upstreams/authentication/consts.go
@@ -5,7 +5,3 @@ const (
 	authTypeOAuth2          = "oauth2/client_credentials"
 	authTypeActiveDirectory = "activedirectory/client_credentials"
 )
-
-var (
-	authTypes = []string{authTypeForwardHeader, authTypeOAuth2, authTypeActiveDirectory}
-)

--- a/services/graphql-server/extensions/upstreams/authentication/forward_auth_header.go
+++ b/services/graphql-server/extensions/upstreams/authentication/forward_auth_header.go
@@ -1,0 +1,34 @@
+package authentication
+
+import (
+	"agogos/server/runtime"
+	"context"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+type forwardHeaderAuth struct{}
+
+var authHeaderForwarder = forwardHeaderAuth{}
+
+func (ucc forwardHeaderAuth) AddAuthentication(ctx context.Context, req *http.Request, scope string) {
+	originalRequest := runtime.GetRequest(ctx)
+	if originalRequest == nil {
+		logrus.Panic("Could not find request in context, this should never happen")
+		return
+	}
+
+	authHeader := originalRequest.Header.Get("Authorization")
+
+	if authHeader == "" {
+		logrus.Info("Could not find authorization header, not forwarding")
+		return
+	}
+
+	req.Header.Set("Authorization", authHeader)
+}
+
+func newForwardAuthHeader() UpstreamAuthentication {
+	return authHeaderForwarder
+}

--- a/services/graphql-server/extensions/upstreams/authentication/upstream_authentication.go
+++ b/services/graphql-server/extensions/upstreams/authentication/upstream_authentication.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"context"
 	"net/http"
 
 	agogos "agogos/generated"
@@ -8,9 +9,35 @@ import (
 
 // UpstreamAuthentication interface for UpstreamAuthentication extension. Supplies auth details to HTTP request
 type UpstreamAuthentication interface {
-	AddAuthentication(req *http.Request, scope string)
+	AddAuthentication(ctx context.Context, req *http.Request, scope string)
 }
 
-func CreateFromConfig(uac *agogos.UpstreamAuthCredentials) UpstreamAuthentication {
+func createFromConfig(uac *agogos.UpstreamAuthCredentials) UpstreamAuthentication {
 	return newUpstreamClientCredentials(uac)
+}
+
+type AuthMap map[string]map[string]UpstreamAuthentication
+
+func (am AuthMap) Get(authType, authority string) UpstreamAuthentication {
+	if authType == authTypeForwardHeader {
+		return newForwardAuthHeader()
+	}
+
+	if m, ok := am[authType]; ok {
+		return m[authority]
+	} else {
+		return nil
+	}
+}
+
+func CreateFromConfig(upsAuthConfigs []*agogos.UpstreamAuthCredentials) AuthMap {
+	am := make(AuthMap)
+	for _, upsAuthConfig := range upsAuthConfigs {
+		if _, ok := am[upsAuthConfig.AuthType]; !ok {
+			am[upsAuthConfig.AuthType] = make(map[string]UpstreamAuthentication)
+		}
+
+		am[upsAuthConfig.AuthType][upsAuthConfig.Authority] = createFromConfig(upsAuthConfig)
+	}
+	return am
 }

--- a/services/graphql-server/extensions/upstreams/authentication/upstream_authentication.go
+++ b/services/graphql-server/extensions/upstreams/authentication/upstream_authentication.go
@@ -12,10 +12,6 @@ type UpstreamAuthentication interface {
 	AddAuthentication(ctx context.Context, req *http.Request, scope string)
 }
 
-func createFromConfig(uac *agogos.UpstreamAuthCredentials) UpstreamAuthentication {
-	return newUpstreamClientCredentials(uac)
-}
-
 type AuthMap map[string]map[string]UpstreamAuthentication
 
 func (am AuthMap) Get(authType, authority string) UpstreamAuthentication {
@@ -30,14 +26,14 @@ func (am AuthMap) Get(authType, authority string) UpstreamAuthentication {
 	}
 }
 
-func CreateFromConfig(upsAuthConfigs []*agogos.UpstreamAuthCredentials) AuthMap {
+func CreateUpstreamAuths(upsAuthConfigs []*agogos.UpstreamAuthCredentials) AuthMap {
 	am := make(AuthMap)
 	for _, upsAuthConfig := range upsAuthConfigs {
 		if _, ok := am[upsAuthConfig.AuthType]; !ok {
 			am[upsAuthConfig.AuthType] = make(map[string]UpstreamAuthentication)
 		}
 
-		am[upsAuthConfig.AuthType][upsAuthConfig.Authority] = createFromConfig(upsAuthConfig)
+		am[upsAuthConfig.AuthType][upsAuthConfig.Authority] = newUpstreamClientCredentials(upsAuthConfig)
 	}
 	return am
 }

--- a/services/graphql-server/extensions/upstreams/authentication/upstream_client_credentials.go
+++ b/services/graphql-server/extensions/upstreams/authentication/upstream_client_credentials.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,7 @@ type upstreamClientCredentials struct {
 }
 
 // AddAuthentication implements interface AuthProvider, adds Authorization header to HTTP request
-func (ucc *upstreamClientCredentials) AddAuthentication(req *http.Request, scope string) {
+func (ucc *upstreamClientCredentials) AddAuthentication(ctx context.Context, req *http.Request, scope string) {
 	tokenSource := ucc.getOrCreateTokenSource(scope)
 	tok, err := tokenSource.Token()
 

--- a/services/graphql-server/extensions/upstreams/upstream.go
+++ b/services/graphql-server/extensions/upstreams/upstream.go
@@ -3,12 +3,13 @@ package upstreams
 import (
 	"agogos/extensions/upstreams/authentication"
 	agogos "agogos/generated"
+	"context"
 	"net/http"
 )
 
 // Upstream - interface for upstream extension. Allows to change @http directive url or to add headers to http request created in resolver
 type Upstream interface {
-	ApplyUpstream(req *http.Request)
+	ApplyUpstream(ctx context.Context, req *http.Request)
 }
 
 type upstreamStruct struct {
@@ -24,13 +25,13 @@ type authStruct struct {
 	scope     string
 }
 
-func (up *upstreamStruct) ApplyUpstream(req *http.Request) {
+func (up *upstreamStruct) ApplyUpstream(ctx context.Context, req *http.Request) {
 	for header, headerValue := range up.headers {
 		req.Header.Set(header, headerValue)
 	}
 
 	if up.upstreamAuth != nil {
-		up.upstreamAuth.AddAuthentication(req, up.auth.scope)
+		up.upstreamAuth.AddAuthentication(ctx, req, up.auth.scope)
 	}
 }
 

--- a/services/graphql-server/extensions/upstreams/upstream.go
+++ b/services/graphql-server/extensions/upstreams/upstream.go
@@ -35,7 +35,7 @@ func (up *upstreamStruct) ApplyUpstream(ctx context.Context, req *http.Request) 
 	}
 }
 
-func CreateFromConfig(upConfig *agogos.Upstream, upsAuth authentication.UpstreamAuthentication) Upstream {
+func CreateUpstream(upConfig *agogos.Upstream, upsAuth authentication.UpstreamAuthentication) Upstream {
 	return &upstreamStruct{
 		host: upConfig.Host,
 		auth: authStruct{

--- a/services/graphql-server/main.go
+++ b/services/graphql-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"agogos/registry"
 	"agogos/schema"
+	"agogos/server/runtime"
 	"context"
 	"net/http"
 
@@ -70,6 +71,7 @@ func main() {
 
 	graphqlHandler := metrics.InstrumentHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if graphqlHTTPHandler != nil {
+			r = runtime.BindRequestContext(r)
 			graphqlHTTPHandler.ServeHTTP(w, r)
 		} else {
 			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)

--- a/services/graphql-server/schema/process.go
+++ b/services/graphql-server/schema/process.go
@@ -48,12 +48,12 @@ func transformToSchema(config *agogos.ConfigurationMessage) (*graphql.Schema, er
 }
 
 func createUpstreams(upsConfigs []*agogos.Upstream, upsAuthConfigs []*agogos.UpstreamAuthCredentials) map[string]upstreams.Upstream {
-	authMap := authentication.CreateFromConfig(upsAuthConfigs)
+	authMap := authentication.CreateUpstreamAuths(upsAuthConfigs)
 	ups := make(map[string]upstreams.Upstream, len(upsConfigs))
 
 	for _, upConfig := range upsConfigs {
 		auth := authMap.Get(upConfig.Auth.AuthType, upConfig.Auth.Authority)
-		ups[upConfig.Host] = upstreams.CreateFromConfig(upConfig, auth)
+		ups[upConfig.Host] = upstreams.CreateUpstream(upConfig, auth)
 	}
 
 	return ups

--- a/services/graphql-server/server/runtime/request.go
+++ b/services/graphql-server/server/runtime/request.go
@@ -1,0 +1,25 @@
+package runtime
+
+import (
+	"context"
+	"net/http"
+)
+
+type requestKey struct{}
+
+func GetRequest(ctx context.Context) *http.Request {
+	val := ctx.Value(requestKey{})
+
+	if r, ok := val.(*http.Request); ok {
+		return r
+	} else {
+		return nil
+	}
+}
+
+func BindRequestContext(r *http.Request) *http.Request {
+	parentCtx := r.Context()
+	ctx := context.WithValue(parentCtx, requestKey{}, r)
+
+	return r.WithContext(ctx)
+}

--- a/services/registry/src/sync/sync-grpc-server.ts
+++ b/services/registry/src/sync/sync-grpc-server.ts
@@ -45,8 +45,14 @@ class GqlConfigurationSubscriptionServer implements IRegistryServer {
                     const upstreamAuth = new UpstreamAuthentication();
                     // FIXME: get from ep
                     upstreamAuth.setAuthType(ep.auth.authType);
-                    upstreamAuth.setAuthority(ep.auth.authority);
-                    upstreamAuth.setScope(ep.auth.scope);
+                    if (ep.auth.authority) {
+                        upstreamAuth.setAuthority(ep.auth.authority);
+                    }
+
+                    if (ep.auth.scope) {
+                        upstreamAuth.setScope(ep.auth.scope);
+                    }
+                    
                     upstream.setAuth(upstreamAuth);
 
                     return upstream;


### PR DESCRIPTION
* The originating HTTP request can now be accessed on the Context object
* Refactored upstream/upstream auth creation to support forward_auth_header type