### PR TITLE
Param replacement util

### DIFF
--- a/services/graphql-server/utils/identity.go
+++ b/services/graphql-server/utils/identity.go
@@ -6,6 +6,8 @@ func IdentityResolver(fieldName string, source interface{}) (res interface{}, er
 	defer Recovery(&err)
 
 	switch source.(type) {
+	case nil:
+		res = nil
 
 	case map[string]interface{}:
 		m := source.(map[string]interface{})

--- a/services/graphql-server/utils/identity_test.go
+++ b/services/graphql-server/utils/identity_test.go
@@ -34,6 +34,13 @@ func TestStructMissingValue(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestNilStruct(t *testing.T) {
+	result, err := IdentityResolver("Nope", nil)
+
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+}
+
 type Person struct {
 	Name string
 }

--- a/services/graphql-server/utils/param_replacement.go
+++ b/services/graphql-server/utils/param_replacement.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/graphql-go/graphql"
+)
+
+var re = regexp.MustCompile(`{\w+\.\w+}`)
+
+func resolveFromParams(rp graphql.ResolveParams, sourceName string, propName string) interface{} {
+	switch sourceName {
+	case "args":
+		val, ok := rp.Args[propName]
+		if !ok {
+			return nil
+		}
+		return val
+	case "source":
+		res, err := IdentityResolver(propName, rp.Source)
+		if err != nil {
+			return nil
+		}
+		return res
+	default:
+		return nil
+	}
+}
+
+// ReplaceWithParameters replaces template strings that look like "something {args.id} {source.someotherprop}", replacing those templates with the corresponding properties in the ResolveParams
+func ReplaceWithParameters(rp graphql.ResolveParams, str string) string {
+	return re.ReplaceAllStringFunc(str, func(s string) string {
+		sepIndex := strings.IndexRune(s, '.')
+
+		sourceName := s[1:sepIndex]
+		propName := s[sepIndex+1 : len(s)-1]
+		prop := resolveFromParams(rp, sourceName, propName)
+		if prop == nil {
+			return ""
+		}
+
+		return fmt.Sprintf("%v", prop)
+	})
+}

--- a/services/graphql-server/utils/param_replacement_test.go
+++ b/services/graphql-server/utils/param_replacement_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasic(t *testing.T) {
+	rp := graphql.ResolveParams{
+		Args:   map[string]interface{}{"arg1": "arg"},
+		Source: map[string]interface{}{"source1": "source"},
+	}
+
+	res := ReplaceWithParameters(rp, "{args.arg1} - {source.source1}")
+
+	assert.Equal(t, "arg - source", res)
+}
+
+func TestMissingProp(t *testing.T) {
+	rp := graphql.ResolveParams{
+		Args:   map[string]interface{}{},
+		Source: map[string]interface{}{},
+	}
+
+	res := ReplaceWithParameters(rp, ">a{args.not_there}b<")
+
+	assert.Equal(t, ">ab<", res)
+}
+
+func TestZeroResolveParams(t *testing.T) {
+	rp := graphql.ResolveParams{}
+
+	res := ReplaceWithParameters(rp, ">{args.not_there}<>{source.not_there_either}<")
+
+	assert.Equal(t, "><><", res)
+}


### PR DESCRIPTION
Note: I also tried using go templates for this, and benchmarked it, with very similar results (it was faster by 50-100 ns per operation)
Eventually chose regex because I don't want clients to be able to do wacky things with templates like `localhost/{if gt .args.id 1000}c1{else}v2{end}/users`