### PR TITLE
Policy directive - accept only a single policy

### DIFF
--- a/services/src/modules/directives/policy/policy-query.ts
+++ b/services/src/modules/directives/policy/policy-query.ts
@@ -19,8 +19,7 @@ export class PolicyQueryDirective extends SchemaDirectiveVisitor {
                 args: args,
             };
 
-            const executor = new PolicyExecutor(policy, parent, args, context, info);
-            const allow = await executor.evaluatePolicy();
+            const allow = await PolicyExecutor.evaluatePolicy(policy, parent, args, context, info);
             return {allow};
         };
     }

--- a/services/src/modules/directives/policy/policy-query.ts
+++ b/services/src/modules/directives/policy/policy-query.ts
@@ -19,8 +19,8 @@ export class PolicyQueryDirective extends SchemaDirectiveVisitor {
                 args: args,
             };
 
-            const executor = new PolicyExecutor([], parent, args, context, info);
-            const allow = await executor.evaluatePolicy(policy);
+            const executor = new PolicyExecutor(policy, parent, args, context, info);
+            const allow = await executor.evaluatePolicy();
             return {allow};
         };
     }

--- a/services/src/modules/directives/policy/policy.ts
+++ b/services/src/modules/directives/policy/policy.ts
@@ -13,8 +13,7 @@ export class PolicyDirective extends SchemaDirectiveVisitor {
 
         field.resolve = async (parent: any, args: any, context: RequestContext, info: GraphQLResolveInfo) => {
             if (!context.ignorePolicies) {
-                const executor = new PolicyExecutor(policy, parent, args, context, info);
-                await executor.validatePolicy();
+                await PolicyExecutor.validatePolicy(policy, parent, args, context, info);
             }
 
             return originalResolve.call(field, parent, args, context, info);

--- a/services/src/tests/e2e/tests/__snapshots__/authorization_with_queries.spec.ts.snap
+++ b/services/src/tests/e2e/tests/__snapshots__/authorization_with_queries.spec.ts.snap
@@ -10,9 +10,7 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy alwaysDenied in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:42:19)",
-            "    at async Promise.all (index 0)",
-            "    at async PolicyExecutor.validatePolicies (/service/dist/modules/directives/policy/policy-executor.js:20:9)",
+            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
             "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
           ],
         },
@@ -58,9 +56,7 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy notClassified in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:42:19)",
-            "    at async Promise.all (index 0)",
-            "    at async PolicyExecutor.validatePolicies (/service/dist/modules/directives/policy/policy-executor.js:20:9)",
+            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
             "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
           ],
         },
@@ -99,9 +95,7 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy notClassified in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:42:19)",
-            "    at async Promise.all (index 0)",
-            "    at async PolicyExecutor.validatePolicies (/service/dist/modules/directives/policy/policy-executor.js:20:9)",
+            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
             "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
           ],
         },

--- a/services/src/tests/e2e/tests/__snapshots__/authorization_with_queries.spec.ts.snap
+++ b/services/src/tests/e2e/tests/__snapshots__/authorization_with_queries.spec.ts.snap
@@ -10,8 +10,8 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy alwaysDenied in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
-            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
+            "    at Function.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:27:19)",
+            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:13:17)",
           ],
         },
       },
@@ -56,8 +56,8 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy notClassified in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
-            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
+            "    at Function.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:27:19)",
+            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:13:17)",
           ],
         },
       },
@@ -95,8 +95,8 @@ Object {
         "exception": Object {
           "stacktrace": Array [
             "Error: Unauthorized by policy notClassified in namespace namespace",
-            "    at PolicyExecutor.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:38:19)",
-            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:14:17)",
+            "    at Function.validatePolicy (/service/dist/modules/directives/policy/policy-executor.js:27:19)",
+            "    at async field.resolve (/service/dist/modules/directives/policy/policy.js:13:17)",
           ],
         },
       },

--- a/services/src/tests/e2e/tests/authorization_with_queries.spec.ts
+++ b/services/src/tests/e2e/tests/authorization_with_queries.spec.ts
@@ -82,14 +82,14 @@ const schema: Schema = {
       name: String
       hireDate: Int
       department: Department!
-      address: String @policy(policies: [{
+      address: String @policy(
         namespace: "namespace",
         name: "notClassified",
         args: {
           departmentId: "{source.department.id}",
           hireDate: "{source.hireDate}"
         }
-      }])
+      )
     }
 
     type Query {
@@ -126,10 +126,7 @@ const schema: Schema = {
       classifiedDepartments: [Department!]! @stub(value: [{
         id: "D1000"
         name: "VIP"
-      }]) @policy(policies: [{
-        namespace: "namespace",
-        name: "alwaysDenied"
-      }])
+      }]) @policy(namespace: "namespace", name: "alwaysDenied")
     }
   `,
 };

--- a/services/src/tests/helpers/authzSchema.ts
+++ b/services/src/tests/helpers/authzSchema.ts
@@ -39,19 +39,19 @@ export const getSchema = () => ({
     schema: `
     type User {
       firstName: String
-      lastName: String @policy(policies: [
-        { namespace: "ns", name: "onlyAdmin", args: { role: "{source.role}" } }
-      ])
+      lastName: String @policy(namespace: "ns", name: "onlyAdmin", args: { role: "{source.role}" })
       role: String
     }
 
     type ArbitraryData {
-      arbitraryField: String @policy(policies: [
-        { namespace: "ns", name: "jwtName", args: {
+      arbitraryField: String @policy(
+        namespace: "ns",
+        name: "jwtName",
+        args: {
           jwtName: "{jwt.name}",
           allowedName: "Varg"
-        }}
-      ])
+        }
+      )
     }
 
     type Query {


### PR DESCRIPTION
- Change Policy directive to accept only a single policy instead of an array of policies.
- Refactored PolicyExecutor API to only expose static methods.
Internals still work the same for brevity, but consumers of the class will no longer have to instantiate a class to call only a single method.

I recommend reviewing each commit individually.