### PR TITLE
Policy attachment changes

### DIFF
--- a/services/src/modules/directives/policy/policy-executor.ts
+++ b/services/src/modules/directives/policy/policy-executor.ts
@@ -50,7 +50,7 @@ export default class PolicyExecutor extends CachedOperation<PolicyCacheKey, bool
     const evaluate = typeEvaluators[ctx.policyDefinition.type];
     if (!evaluate) throw new Error(`Unsupported policy type ${ctx.policyDefinition.type}`);
 
-    const { done, allow } = await evaluate({
+    const { done, allow } = evaluate({
       ...ctx.policy,
       args,
       query,

--- a/services/src/modules/directives/policy/types.ts
+++ b/services/src/modules/directives/policy/types.ts
@@ -54,3 +54,8 @@ export type PolicyCacheKey = {
   metadata: ResourceMetadata;
   args?: PolicyArgsObject;
 };
+
+// Temporary until opa-wasm package adds types
+export interface LoadedPolicy {
+  evaluate: (input: { [key: string]: any }) => any[];
+}

--- a/services/src/modules/directives/policy/types.ts
+++ b/services/src/modules/directives/policy/types.ts
@@ -57,5 +57,5 @@ export type PolicyCacheKey = {
 
 // Temporary until opa-wasm package adds types
 export interface LoadedPolicy {
-  evaluate: (input: { [key: string]: any }) => any[];
+  evaluate: (input: Record<string, unknown>) => any[];
 }

--- a/services/src/modules/resource-repository/fs-repository.ts
+++ b/services/src/modules/resource-repository/fs-repository.ts
@@ -8,9 +8,10 @@ export class FileSystemResourceRepository extends ResourceRepository {
   constructor(
     protected storage: FileSystemStorage,
     protected resourceFilePath: string,
-    protected policyAttachmentsFolderPath: string
+    protected policyAttachmentsFolderPath: string,
+    protected isRegistry = false
   ) {
-    super(storage, resourceFilePath, policyAttachmentsFolderPath);
+    super(storage, resourceFilePath, policyAttachmentsFolderPath, isRegistry);
   }
 
   async writePolicyAttachment(filename: string, content: Buffer): Promise<void> {
@@ -25,7 +26,7 @@ export class FileSystemResourceRepository extends ResourceRepository {
     this.policyAttachmentsFolderInitialized = true;
   }
 
-  static fromEnvironment() {
+  static fromEnvironment(options: { isRegistry: boolean } = { isRegistry: false }) {
     const resourceFilePath = envVar.get('FS_RESOURCE_REPOSITORY_PATH').required().asString();
     const policyAttachmentsFolderPath = envVar
       .get('FS_REPOSITORY_POLICY_ATTACHMENTS_FOLDER_PATH')
@@ -33,6 +34,11 @@ export class FileSystemResourceRepository extends ResourceRepository {
       .asString();
 
     const fsStorage = new FileSystemStorage();
-    return new FileSystemResourceRepository(fsStorage, resourceFilePath, policyAttachmentsFolderPath);
+    return new FileSystemResourceRepository(
+      fsStorage,
+      resourceFilePath,
+      policyAttachmentsFolderPath,
+      options.isRegistry
+    );
   }
 }

--- a/services/src/modules/resource-repository/s3-repository.ts
+++ b/services/src/modules/resource-repository/s3-repository.ts
@@ -8,9 +8,10 @@ export class S3ResourceRepository extends ResourceRepository {
   constructor(
     protected storage: S3Storage,
     protected resourceFilePath: string,
-    protected policyAttachmentsFolderPath: string
+    protected policyAttachmentsFolderPath: string,
+    protected isRegistry = false
   ) {
-    super(storage, resourceFilePath, policyAttachmentsFolderPath);
+    super(storage, resourceFilePath, policyAttachmentsFolderPath, isRegistry);
   }
 
   async fetchLatest(): Promise<FetchLatestResult> {
@@ -41,7 +42,7 @@ export class S3ResourceRepository extends ResourceRepository {
     return { isNew: true, resourceGroup: resources };
   }
 
-  static fromEnvironment() {
+  static fromEnvironment(options: { isRegistry: boolean } = { isRegistry: false }) {
     const s3endpoint = envVar.get('S3_ENDPOINT').required().asString();
     const bucketName = envVar.get('S3_RESOURCE_BUCKET_NAME').required().asString();
     const resourceFilePath = envVar.get('S3_RESOURCE_OBJECT_KEY').default('resources.json').asString();
@@ -53,7 +54,7 @@ export class S3ResourceRepository extends ResourceRepository {
     const awsSecretAccessKey = envVar.get('S3_AWS_SECRET_ACCESS_KEY').asString();
 
     const s3Storage = new S3Storage(bucketName, s3endpoint, awsAccessKeyId, awsSecretAccessKey);
-    return new S3ResourceRepository(s3Storage, resourceFilePath, policyAttachmentsFolderPath);
+    return new S3ResourceRepository(s3Storage, resourceFilePath, policyAttachmentsFolderPath, options.isRegistry);
   }
 }
 

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -1,3 +1,5 @@
+import { LoadedPolicy } from '../directives/policy/types';
+
 export interface ResourceGroup {
   schemas: Schema[];
   upstreams: Upstream[];
@@ -65,7 +67,9 @@ export interface FetchLatestResult {
   resourceGroup: ResourceGroup;
 }
 
-export type PolicyAttachments = { [filename: string]: Buffer };
+export type PolicyAttachments = {
+  [filename: string]: LoadedPolicy;
+};
 
 export interface IResourceRepository {
   fetchLatest(): Promise<FetchLatestResult>;

--- a/services/src/registry.ts
+++ b/services/src/registry.ts
@@ -180,7 +180,7 @@ interface PolicyInput {
   query?: PolicyQueryInput;
 }
 
-const resourceRepository = S3ResourceRepository.fromEnvironment();
+const resourceRepository = S3ResourceRepository.fromEnvironment({ isRegistry: true });
 
 async function fetchAndValidate(updates: Partial<ResourceGroup>): Promise<ResourceGroup> {
   const { resourceGroup } = await resourceRepository.fetchLatest();

--- a/services/tests/integration/gateway/policy-caching.spec.ts
+++ b/services/tests/integration/gateway/policy-caching.spec.ts
@@ -9,7 +9,7 @@ import PolicyExecutor from '../../../src/modules/directives/policy/policy-execut
 import { beforeEachDispose } from '../before-each-dispose';
 
 jest.mock('../../../src/modules/directives/policy/opa', () => ({
-  evaluate: jest.fn(() => Promise.resolve({ done: true, allow: true })),
+  evaluate: jest.fn(() => ({ done: true, allow: true })),
 }));
 
 const userSchema: Schema = {


### PR DESCRIPTION
Don't load policy attachments cache when on registry
Save the loaded WASM instances in the policy attachments cache instead of the buffer of the WASM code