### PR TITLE
Allow policies to work with namespace and policy names that have dashes

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -96,6 +96,8 @@ If one policy is dependent on another the `query` property can include the follo
 
 The policy arguments should be set as the query arguments.
 
+Note that due to graphql naming limitations, the name of the policy query has dashes replaced with underscores for both the namespace and the policy name (e.g. namespace `some-ns` and policy name `some-policy` will be called using `policy.some_ns___some_policy`)
+
 In the example below the query has 2 parts: the first one fetches `roles` field from `user` and the second part evaluates `userIsActive`.
 
 ```yaml

--- a/services/src/modules/__snapshots__/validation.spec.ts.snap
+++ b/services/src/modules/__snapshots__/validation.spec.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validateMetadataCharacters - Validation that namespaces and names contain only valid gql chars and dashes throws when namespace names contain invalid chars 1`] = `
+{
+  "errors": [
+    {
+      "name": "GraphQLError",
+      "message": "Invalid characters found in namespace name special_not_allowed_@@ of resource type schemas, allowed characters are /^[A-Z_a-z-][\\\\w-]*$/",
+      "exception": {}
+    }
+  ],
+  "data": {}
+}
+`;
+
+exports[`validateMetadataCharacters - Validation that namespaces and names contain only valid gql chars and dashes throws when resource names contain invalid chars 1`] = `
+{
+  "errors": [
+    {
+      "name": "GraphQLError",
+      "message": "Invalid characters found in resource name special_not_allowed_$$ of resource type policies, allowed characters are /^[A-Z_a-z-][\\\\w-]*$/",
+      "exception": {}
+    }
+  ],
+  "data": {}
+}
+`;
+
+exports[`validateMetadataNameConflicts throws when two namespace names are similar, differing only between underscores and dashes 1`] = `
+{
+  "errors": [
+    {
+      "name": "GraphQLError",
+      "message": "Namespace name conflict found between some-ns and some_ns, they have to either match exactly or have a difference in non-special characters",
+      "exception": {}
+    }
+  ],
+  "data": {}
+}
+`;
+
+exports[`validateMetadataNameConflicts throws when two resource names from the same namespace and resource type are similar, differing only between underscores and dashes 1`] = `
+{
+  "errors": [
+    {
+      "name": "GraphQLError",
+      "message": "Resource name conflict found between policy-1 and policy_1 of resource type policies in namespace some-ns, they have to either match exactly or have a difference in non-special characters",
+      "exception": {}
+    }
+  ],
+  "data": {}
+}
+`;

--- a/services/src/modules/validation.spec.ts
+++ b/services/src/modules/validation.spec.ts
@@ -1,0 +1,89 @@
+import { validateResourceGroupOrThrow } from './validation';
+import { ResourceGroup, PolicyType } from './resource-repository';
+
+describe('validateNamespaceAndPolicyNames - Validation that namespace and policy names contain only valid gql chars and dashes', () => {
+  let rg: ResourceGroup;
+
+  beforeEach(() => {
+    rg = {
+      schemas: [{ metadata: { namespace: 'some-ns', name: 'special_allowed_here_@@' }, schema: 'schema' }],
+      upstreams: [],
+      upstreamClientCredentials: [],
+      policies: [{ metadata: { namespace: 'other-ns', name: 'valid-chars_only' }, type: PolicyType.opa, code: 'code' }],
+    };
+  });
+
+  it("doesn't throw when names are valid", () => {
+    expect(() => validateResourceGroupOrThrow(rg)).not.toThrow();
+  });
+
+  it('throws when namespace names contain invalid chars', () => {
+    rg.schemas[0].metadata.namespace = 'special_not_allowed_@@';
+    expect.assertions(1);
+
+    try {
+      validateResourceGroupOrThrow(rg);
+    } catch (err) {
+      expect(err.errors?.[0]?.message).toEqual(
+        'Invalid characters found in namespace name special_not_allowed_@@, allowed characters are /^[A-Z_a-z-][\\w-]*$/'
+      );
+    }
+  });
+
+  it('throws when policy names contain invalid chars', () => {
+    rg.policies[0].metadata.name = 'special_not_allowed_$$';
+    expect.assertions(1);
+
+    try {
+      validateResourceGroupOrThrow(rg);
+    } catch (err) {
+      expect(err.errors?.[0]?.message).toEqual(
+        'Invalid characters found in policy name special_not_allowed_$$, allowed characters are /^[A-Z_a-z-][\\w-]*$/'
+      );
+    }
+  });
+});
+
+describe('validateNamespaceAndPolicyNameConflicts', () => {
+  let rg: ResourceGroup;
+
+  beforeEach(() => {
+    rg = {
+      schemas: [{ metadata: { namespace: 'some-ns', name: 'schema-name' }, schema: 'schema' }],
+      upstreams: [],
+      upstreamClientCredentials: [],
+      policies: [
+        { metadata: { namespace: 'some-ns', name: 'policy-1' }, type: PolicyType.opa, code: 'code' },
+        { metadata: { namespace: 'some-ns', name: 'policy-2' }, type: PolicyType.opa, code: 'code' },
+      ],
+    };
+  });
+
+  it("doesn't throw when multiple resources have the same namespace name", () => {
+    expect(() => validateResourceGroupOrThrow(rg)).not.toThrow();
+  });
+
+  it('throws when two namespace names are similar, differing only between underscores and dashes', () => {
+    rg.schemas[0].metadata.namespace = 'some_ns';
+
+    try {
+      validateResourceGroupOrThrow(rg);
+    } catch (err) {
+      expect(err.errors?.[0]?.message).toEqual(
+        'Namespace name conflict found between some_ns and some-ns, they have to either match exactly or have a difference in non-special characters'
+      );
+    }
+  });
+
+  it('throws when two policy names are similar, differing only between underscores and dashes', () => {
+    rg.policies[1].metadata.name = 'policy_1';
+
+    try {
+      validateResourceGroupOrThrow(rg);
+    } catch (err) {
+      expect(err.errors?.[0]?.message).toEqual(
+        'Policy name conflict found between policy-1 and policy_1, they have to either match exactly or have a difference in non-special characters'
+      );
+    }
+  });
+});

--- a/services/src/modules/validation.ts
+++ b/services/src/modules/validation.ts
@@ -1,6 +1,11 @@
 import { ApolloError } from 'apollo-server-fastify';
 import { GraphQLError } from 'graphql';
-import { ResourceGroup, Upstream } from './resource-repository';
+import { ResourceGroup, Upstream, Resource } from './resource-repository';
+
+// Valid graphql name with the addition of dashes (http://spec.graphql.org/June2018/#sec-Names)
+const validNameRegex = /^[A-Z_a-z-][\w-]*$/;
+
+const resourceTypesWithMetadata = new Set(['schemas', 'upstreams', 'upstreamClientCredentials', 'policies']);
 
 function validateUpstreams(upstreams: Upstream[]) {
   const errors: GraphQLError[] = [];
@@ -39,12 +44,101 @@ function validateUpstreams(upstreams: Upstream[]) {
   return errors;
 }
 
+function validateNamespaceAndPolicyNames(rg: ResourceGroup) {
+  const errors: GraphQLError[] = [];
+
+  for (const [resourceType, resources] of Object.entries(rg) as [string, Resource[]][]) {
+    if (!resourceTypesWithMetadata.has(resourceType)) continue;
+
+    for (const resource of resources) {
+      const { name, namespace } = resource.metadata;
+
+      if (!validNameRegex.test(namespace)) {
+        errors.push(
+          new ApolloError(
+            `Invalid characters found in namespace name ${namespace}, allowed characters are /${validNameRegex.source}/`,
+            'INVALID_CHARACTERS_IN_NAME',
+            { resource: { type: resourceType, namespace, name } }
+          )
+        );
+      }
+
+      if (resourceType === 'policies' && !validNameRegex.test(name)) {
+        errors.push(
+          new ApolloError(
+            `Invalid characters found in policy name ${name}, allowed characters are /${validNameRegex.source}/`,
+            'INVALID_CHARACTERS_IN_NAME',
+            { resource: { type: resourceType, namespace, name } }
+          )
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+// Verifies namespace names and policy names to not have two similar ones differing only between
+// underscores and dashes (e.g. 'some-ns' and 'some_ns' would return a conflict error)
+function validateNamespaceAndPolicyNameConflicts(rg: ResourceGroup) {
+  const errors: GraphQLError[] = [];
+  const existingNamespaces = new Map<string, string>();
+  const existingPolicyNames = new Map<string, string>();
+
+  for (const [resourceType, resources] of Object.entries(rg) as [string, Resource[]][]) {
+    if (!resourceTypesWithMetadata.has(resourceType)) continue;
+
+    for (const resource of resources) {
+      const { name, namespace } = resource.metadata;
+
+      const namespaceWithUnderscores = namespace.replace(/-/g, '_');
+      const existingNamespace = existingNamespaces.get(namespaceWithUnderscores);
+      if (!existingNamespace) {
+        existingNamespaces.set(namespaceWithUnderscores, namespace);
+      } else {
+        if (existingNamespace !== namespace) {
+          errors.push(
+            new ApolloError(
+              `Namespace name conflict found between ${existingNamespace} and ${namespace}, they have to either match exactly or have a difference in non-special characters`,
+              'NAME_CONFLICT',
+              { resource: { type: resourceType, namespace, name } }
+            )
+          );
+        }
+      }
+
+      if (resourceType === 'policies') {
+        const nameWithUnderscores = name.replace(/-/g, '_');
+        const existingName = existingPolicyNames.get(nameWithUnderscores);
+        if (!existingName) {
+          existingPolicyNames.set(nameWithUnderscores, name);
+        } else {
+          if (existingName !== name) {
+            errors.push(
+              new ApolloError(
+                `Policy name conflict found between ${existingName} and ${name}, they have to either match exactly or have a difference in non-special characters`,
+                'NAME_CONFLICT',
+                { resource: { type: resourceType, namespace, name } }
+              )
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function validateResourceGroupOrThrow(rg: ResourceGroup) {
   const errors: GraphQLError[] = [];
 
   if (rg.upstreams.length > 0) {
     errors.push(...validateUpstreams(rg.upstreams));
   }
+
+  errors.push(...validateNamespaceAndPolicyNames(rg));
+  errors.push(...validateNamespaceAndPolicyNameConflicts(rg));
 
   if (errors.length > 0) {
     throw new ApolloError('Resource validation failed', 'RESOURCE_VALIDATION_FAILURE', {

--- a/services/src/registry.ts
+++ b/services/src/registry.ts
@@ -214,10 +214,10 @@ const resolvers: IResolvers = {
   Query: {
     async validateResourceGroup(_, args: { input: ResourceGroupInput }) {
       const policyAttachments = new PolicyAttachmentsGenerator(resourceRepository);
-      await policyAttachments.generate(args?.input?.policies ?? []);
 
       try {
         await fetchAndValidate(args.input);
+        await policyAttachments.generate(args?.input?.policies ?? []);
       } finally {
         await policyAttachments.cleanup();
       }
@@ -241,10 +241,10 @@ const resolvers: IResolvers = {
     },
     async validatePolicies(_, args: { input: PolicyInput[] }) {
       const policyAttachments = new PolicyAttachmentsGenerator(resourceRepository);
-      await policyAttachments.generate(args.input);
 
       try {
         await fetchAndValidate({ policies: args.input });
+        await policyAttachments.generate(args.input);
       } finally {
         await policyAttachments.cleanup();
       }
@@ -256,10 +256,10 @@ const resolvers: IResolvers = {
     updateResourceGroup(_, args: { input: ResourceGroupInput }) {
       return singleton(async () => {
         const policyAttachments = new PolicyAttachmentsGenerator(resourceRepository);
-        await policyAttachments.generate(args?.input?.policies ?? []);
 
         try {
           const rg = await fetchAndValidate(args.input);
+          await policyAttachments.generate(args?.input?.policies ?? []);
 
           await policyAttachments.writeToRepo();
           await resourceRepository.update(rg);
@@ -297,10 +297,10 @@ const resolvers: IResolvers = {
     updatePolicies(_, args: { input: PolicyInput[] }) {
       return singleton(async () => {
         const policyAttachments = new PolicyAttachmentsGenerator(resourceRepository);
-        await policyAttachments.generate(args.input);
 
         try {
           const rg = await fetchAndValidate({ policies: args.input });
+          await policyAttachments.generate(args.input);
 
           await policyAttachments.writeToRepo();
           await resourceRepository.update(rg);

--- a/services/tests/e2e/authorization/__snapshots__/auth-with-queries.spec.ts.snap
+++ b/services/tests/e2e/authorization/__snapshots__/auth-with-queries.spec.ts.snap
@@ -8,10 +8,10 @@ Object {
 }
 `;
 
-exports[`Authorization with queries Query alwaysAllow policy 1`] = `
+exports[`Authorization with queries Query always-allow policy 1`] = `
 Object {
   "policy": Object {
-    "auth_with_query___alwaysAllow": Object {
+    "auth_with_query___always_allow": Object {
       "allow": true,
     },
   },
@@ -21,7 +21,7 @@ Object {
 exports[`Authorization with queries Query alwaysDeny policy 1`] = `
 Object {
   "policy": Object {
-    "auth_with_query___alwaysAllow": Object {
+    "auth_with_query___always_allow": Object {
       "allow": true,
     },
   },
@@ -32,7 +32,7 @@ exports[`Authorization with queries Query denied employee 1 1`] = `
 {
   "errors": [
     {
-      "message": "Unauthorized by policy notClassified in namespace auth_with_query",
+      "message": "Unauthorized by policy notClassified in namespace auth-with-query",
       "exception": {
         "code": "INTERNAL_SERVER_ERROR"
       }
@@ -52,7 +52,7 @@ exports[`Authorization with queries Query denied employee 2 1`] = `
 {
   "errors": [
     {
-      "message": "Unauthorized by policy notClassified in namespace auth_with_query",
+      "message": "Unauthorized by policy notClassified in namespace auth-with-query",
       "exception": {
         "code": "INTERNAL_SERVER_ERROR"
       }
@@ -72,7 +72,7 @@ exports[`Authorization with queries Query protected field 1`] = `
 {
   "errors": [
     {
-      "message": "Unauthorized by policy alwaysDenied in namespace auth_with_query",
+      "message": "Unauthorized by policy always-denied in namespace auth-with-query",
       "exception": {
         "code": "INTERNAL_SERVER_ERROR"
       }

--- a/services/tests/e2e/authorization/auth-with-queries.schema.ts
+++ b/services/tests/e2e/authorization/auth-with-queries.schema.ts
@@ -5,8 +5,8 @@ import { PolicyDefinition, PolicyType, Schema } from '../../../src/modules/resou
 export const policies: PolicyDefinition[] = [
   {
     metadata: {
-      name: 'alwaysDenied',
-      namespace: 'auth_with_query',
+      name: 'always-denied',
+      namespace: 'auth-with-query',
     },
     type: PolicyType.opa,
     code: `
@@ -15,8 +15,8 @@ export const policies: PolicyDefinition[] = [
   },
   {
     metadata: {
-      name: 'alwaysAllow',
-      namespace: 'auth_with_query',
+      name: 'always-allow',
+      namespace: 'auth-with-query',
     },
     type: PolicyType.opa,
     code: `
@@ -25,8 +25,8 @@ export const policies: PolicyDefinition[] = [
   },
   {
     metadata: {
-      name: 'isSenior',
-      namespace: 'auth_with_query',
+      name: 'is-senior',
+      namespace: 'auth-with-query',
     },
     type: PolicyType.opa,
     code: `
@@ -42,14 +42,14 @@ export const policies: PolicyDefinition[] = [
   {
     metadata: {
       name: 'notClassified',
-      namespace: 'auth_with_query',
+      namespace: 'auth-with-query',
     },
     type: PolicyType.opa,
     code: `
       default allow = false
       allow {
         input.query.classifiedDepartments[_].id != input.args.departmentId;
-        input.query.policy.auth_with_query___isSenior.allow
+        input.query.policy.auth_with_query___is_senior.allow
       }
     `,
     args: {
@@ -63,7 +63,7 @@ export const policies: PolicyDefinition[] = [
             id
           }
           policy {
-            auth_with_query___isSenior(hireDate: $hireDate) {
+            auth_with_query___is_senior(hireDate: $hireDate) {
               allow
             }
           }
@@ -79,7 +79,7 @@ export const policies: PolicyDefinition[] = [
 export const schema: Schema = {
   metadata: {
     name: 'EmployeeSchema',
-    namespace: 'auth_with_query',
+    namespace: 'auth-with-query',
   },
   schema: print(gql`
     type Department {
@@ -93,7 +93,7 @@ export const schema: Schema = {
       department: Department!
       address: String
         @policy(
-          namespace: "auth_with_query"
+          namespace: "auth-with-query"
           name: "notClassified"
           args: { departmentId: "{source.department.id}", hireDate: "{source.hireDate}" }
         )
@@ -132,7 +132,7 @@ export const schema: Schema = {
         )
       classifiedDepartments: [Department!]!
         @stub(value: [{ id: "D1000", name: "VIP" }])
-        @policy(namespace: "auth_with_query", name: "alwaysDenied")
+        @policy(namespace: "auth-with-query", name: "always-denied")
     }
   `),
 };

--- a/services/tests/e2e/authorization/auth-with-queries.spec.ts
+++ b/services/tests/e2e/authorization/auth-with-queries.spec.ts
@@ -51,12 +51,12 @@ describe('Authorization with queries', () => {
     await sleep(Number(process.env.WAIT_FOR_REFRESH_ON_GATEWAY) | 1500);
   });
 
-  test('Query alwaysAllow policy', async () => {
+  test('Query always-allow policy', async () => {
     const response = await gatewayClient.request(
       print(gql`
         query {
           policy {
-            auth_with_query___alwaysAllow {
+            auth_with_query___always_allow {
               allow
             }
           }
@@ -73,7 +73,7 @@ describe('Authorization with queries', () => {
         print(gql`
           query {
             policy {
-              auth_with_query___alwaysAllow {
+              auth_with_query___always_allow {
                 allow
               }
             }


### PR DESCRIPTION
- Validate that namespace and policy names only use valid graphql chars in addition to dashes
- When creating policy queries on the schema, convert dashes to underscores in the namespace and policy names
- Validate that namespace and policy names have no conflicts - meaning two similar ones that only differ by underscore replaced with dash or vice versa