### PR TITLE
Added status endpoint to registry

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,9 @@
     "unicorn/prefer-spread": "off",
     "unicorn/prefer-string-slice": "off",
     "unicorn/prevent-abbreviations": "off",
+    "unicorn/no-array-reduce": "off",
+    "unicorn/import-style": "off",
+    "unicorn/no-useless-undefined": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
@@ -49,6 +52,8 @@
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "node/no-unpublished-require": "off"
       }
     }
   ],

--- a/services/package.json
+++ b/services/package.json
@@ -5,6 +5,7 @@
     "test": "jest --ci --runInBand --config jest.config.js",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand --config jest.config.js",
     "test:blackbox": "jest --ci --runInBand --config jest.config.blackbox.js",
+    "test:blackbox:debug": "node --inspect node_modules/.bin/jest --runInBand --config jest.config.blackbox.js",
     "test:e2e": "jest --ci --runInBand --config jest.config.e2e.js",
     "test:full": "NODE_OPTIONS=--max_old_space_size=4096 jest --ci --runInBand --config jest.config.full.js",
     "build": "tsc",

--- a/services/src/gateway.ts
+++ b/services/src/gateway.ts
@@ -47,13 +47,13 @@ export async function createServer() {
     app.addHook('onClose', () => server.stop());
   });
 
-  app.get('/health', {}, (_, reply) => {
+  app.get('/health', (_, reply) => {
     reply.status(200).send('OK');
   });
 
-  app.post('/updateSchema', {}, async (_, replay) => {
+  app.post('/updateSchema', async (_, reply) => {
     await updateSchema();
-    replay.status(200).send('OK');
+    reply.status(200).send('OK');
   });
 
   sLogger.info('Stitch gateway is ready to start');

--- a/services/src/modules/authentication/strategies/anonymous.ts
+++ b/services/src/modules/authentication/strategies/anonymous.ts
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import * as fastify from 'fastify';
 import { authenticationConfig } from '../../config';
 
@@ -18,8 +19,10 @@ export default async function (request: AnonymousAuthPartialRequest) {
 
   const anonymousPaths = config.publicPaths;
   if (!anonymousPaths) throw new Error('Unauthorized');
-  if (!anonymousPaths.some(ap => request.raw.url?.endsWith(ap))) {
-    throw new Error('Unauthorized');
-  }
+
+  const url = new URL(request.raw.url ?? '', 'https://localhost:80');
+  const isAnonymous = anonymousPaths.includes(url.pathname);
+  if (!isAnonymous) throw new Error('Unauthorized');
+
   request._isAnonymousAccess = true;
 }

--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -51,7 +51,7 @@ export const ignorePolicies =
 // Authentication
 const defaultAuthenticationConfig: AuthenticationConfig = {
   anonymous: {
-    publicPaths: ['/metrics', '/.well-known/apollo/server-health', '/graphql'],
+    publicPaths: ['/metrics', '/.well-known/apollo/server-health', '/graphql', '/status'],
   },
 };
 export const authenticationConfig =

--- a/services/src/modules/resource-repository/composite.ts
+++ b/services/src/modules/resource-repository/composite.ts
@@ -1,4 +1,11 @@
-import { FetchLatestResult, IResourceRepository, applyResourceGroupUpdates, ResourceRepository } from '.';
+import { listFilesItem } from '../storage';
+import {
+  FetchLatestResult,
+  IResourceRepository,
+  applyResourceGroupUpdates,
+  ResourceRepository,
+  ResourcesMetadata,
+} from '.';
 
 export class CompositeResourceRepository implements IResourceRepository {
   constructor(protected repositories: ResourceRepository[]) {}
@@ -10,6 +17,14 @@ export class CompositeResourceRepository implements IResourceRepository {
       isNew: res1.isNew || res2.isNew,
       resourceGroup: applyResourceGroupUpdates(res1.resourceGroup, res2.resourceGroup),
     }));
+  }
+
+  async fetchMetadata(): Promise<ResourcesMetadata> {
+    throw new Error('Multiplexed resource repository cannot return metadata');
+  }
+
+  async listPolicyAttachments(): Promise<listFilesItem[]> {
+    throw new Error('Multiplexed resource repository cannot list Policy Attachments');
   }
 
   async update(): Promise<void> {

--- a/services/src/modules/resource-repository/fs-repository.ts
+++ b/services/src/modules/resource-repository/fs-repository.ts
@@ -37,7 +37,7 @@ export class FileSystemResourceRepository extends ResourceRepository {
     this.policyAttachmentsFolderInitialized = true;
   }
 
-  static fromEnvironment(options: { isRegistry: boolean } = { isRegistry: false }) {
+  static fromEnvironment({ isRegistry = false } = {}) {
     const resourceFilePath = envVar.get('FS_RESOURCE_REPOSITORY_PATH').required().asString();
     const registryResourceFilePath = envVar.get('FS_REGISTRY_RESOURCE_REPOSITORY_PATH').asString();
     const policyAttachmentsFolderPath = envVar
@@ -50,7 +50,7 @@ export class FileSystemResourceRepository extends ResourceRepository {
       fsStorage,
       resourceFilePath,
       policyAttachmentsFolderPath,
-      options.isRegistry,
+      isRegistry,
       registryResourceFilePath
     );
   }

--- a/services/src/modules/resource-repository/s3-repository.ts
+++ b/services/src/modules/resource-repository/s3-repository.ts
@@ -44,13 +44,13 @@ export class S3ResourceRepository extends ResourceRepository {
     return { isNew: true, resourceGroup: resources };
   }
 
-  static fromEnvironment(options: { isRegistry: boolean } = { isRegistry: false }) {
+  static fromEnvironment({ isRegistry = false } = {}) {
     const s3endpoint = envVar.get('S3_ENDPOINT').required().asString();
     const bucketName = envVar.get('S3_RESOURCE_BUCKET_NAME').required().asString();
     const resourceFilePath = envVar.get('S3_RESOURCE_OBJECT_KEY').default('resources-gateway.json').asString();
 
     let registryResourceEnvVar = envVar.get('S3_REGISTRY_RESOURCE_OBJECT_KEY');
-    if (options.isRegistry) registryResourceEnvVar = registryResourceEnvVar.default('resources-registry.json');
+    if (isRegistry) registryResourceEnvVar = registryResourceEnvVar.default('resources-registry.json');
     const registryResourceFilePath = registryResourceEnvVar.asString();
 
     const policyAttachmentsFolderPath = envVar
@@ -65,7 +65,7 @@ export class S3ResourceRepository extends ResourceRepository {
       s3Storage,
       resourceFilePath,
       policyAttachmentsFolderPath,
-      options.isRegistry,
+      isRegistry,
       registryResourceFilePath
     );
   }

--- a/services/src/modules/resource-repository/types.ts
+++ b/services/src/modules/resource-repository/types.ts
@@ -1,6 +1,7 @@
 import { RemoteSchema } from '../directives/gql';
 import { Policy, LoadedPolicy } from '../directives/policy/types';
 import { PluginMetadata } from '../plugins/types';
+import { listFilesItem } from '../storage';
 
 export type PolicyAttachments = Record<string, LoadedPolicy>;
 export type PolicyQueryVariables = Record<string, unknown>;
@@ -100,9 +101,11 @@ export type UpdateOptions = { registry: boolean };
 
 export interface IResourceRepository {
   fetchLatest(): Promise<FetchLatestResult>;
+  fetchMetadata(): Promise<ResourcesMetadata>;
   update(rg: ResourceGroup, options?: UpdateOptions): Promise<void>;
   writePolicyAttachment(filename: string, content: Buffer): Promise<void>;
   deletePolicyAttachment(filename: string): Promise<void>;
+  listPolicyAttachments(): Promise<listFilesItem[]>;
 }
 
 enum AuthType {

--- a/services/src/modules/status-handler.ts
+++ b/services/src/modules/status-handler.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import { ServerResponse } from 'http';
+import { FastifyRequest, FastifyReply } from 'fastify';
+import logger, { createChildLogger } from './logger';
+import getResourceRepository from './registry-schema/repository';
+import { IResourceRepository, ResourceMetadata, PolicyType } from './resource-repository';
+import { getCompiledFilename } from './opa-helper';
+
+const sLogger = createChildLogger(logger, 'status-endpoint');
+
+export default async function (request: FastifyRequest, reply: FastifyReply<ServerResponse>) {
+  try {
+    const isRegistry = request?.query?.registry === 'true';
+    const repository = getResourceRepository(isRegistry);
+
+    const [metadata, missingOpaPolicyAttachments] = await Promise.all([
+      repository.fetchMetadata(),
+      getMissingOpaPolicyAttachmentNames(repository),
+    ]);
+
+    const result = { metadata, missingOpaPolicyAttachments };
+    reply.status(200).send(result);
+  } catch (err) {
+    sLogger.error(err, 'Error getting data for status endpoint');
+    reply.status(500).send(err?.message);
+  }
+}
+
+async function getMissingOpaPolicyAttachmentNames(repository: IResourceRepository): Promise<ResourceMetadata[]> {
+  const [policyAttachmentsFilenames, policyNames] = await Promise.all([
+    getOpaPolicyAttachmentsFilenames(repository),
+    getOpaPolicyNames(repository),
+  ]);
+
+  return policyNames.filter(policyName => !policyAttachmentsFilenames.has(getCompiledFilename(policyName)));
+}
+
+async function getOpaPolicyAttachmentsFilenames(repository: IResourceRepository): Promise<Map<string, unknown>> {
+  const attachments = await repository.listPolicyAttachments();
+
+  return attachments.reduce(
+    (map, { filePath }) => map.set(path.basename(filePath), undefined),
+    new Map<string, unknown>()
+  );
+}
+
+async function getOpaPolicyNames(repository: IResourceRepository): Promise<ResourceMetadata[]> {
+  const rgResult = await repository.fetchLatest();
+
+  return rgResult.resourceGroup.policies
+    .filter(policy => policy.type === PolicyType.opa)
+    .map(policy => policy.metadata);
+}

--- a/services/src/registry.ts
+++ b/services/src/registry.ts
@@ -12,6 +12,7 @@ import { handleSignals, handleUncaughtErrors } from './modules/shutdown-handler'
 import { loadPlugins } from './modules/plugins';
 import { ActiveDirectoryAuth } from './modules/upstreams';
 import { anonymousPlugin, authStrategies, getSecret, jwtDecoderPlugin } from './modules/authentication';
+import statusHandler from './modules/status-handler';
 
 const sLogger = createChildLogger(logger, 'http-server');
 
@@ -57,6 +58,8 @@ export async function createServer() {
     server.addHook('onRequest', server.auth(authStrategies));
     server.addHook('onClose', () => app.stop());
   });
+
+  server.get('/status', statusHandler);
 
   sLogger.info('Stitch registry is ready to start');
   return server;

--- a/services/tests/blackbox/setup.js
+++ b/services/tests/blackbox/setup.js
@@ -23,7 +23,7 @@ process.env.CORS_CONFIGURATION = JSON.stringify({
 
 process.env.AUTHENTICATION_CONFIGURATION = JSON.stringify({
   anonymous: {
-    publicPaths: ['/metrics', '/.well-known/apollo/server-health', '/graphql', '/updateSchema'],
+    publicPaths: ['/metrics', '/.well-known/apollo/server-health', '/graphql', '/updateSchema', '/status'],
   },
 });
 

--- a/services/tests/blackbox/status-endpoint.spec.ts
+++ b/services/tests/blackbox/status-endpoint.spec.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { FastifyInstance } from 'fastify';
+import { createServer as createRegistry } from '../../src/registry';
+import { ResourcesMetadata, ResourceMetadata, ResourceGroup, PolicyType } from '../../src/modules/resource-repository';
+import { getCompiledFilename } from '../../src/modules/opa-helper';
+
+jest.mock('../../src/modules/directives/policy/opa', () => ({
+  ...(jest.requireActual('../../src/modules/directives/policy/opa') as Record<string, unknown>),
+  getWasmPolicy: jest.fn(() => ({})),
+}));
+
+describe('Status endpoint', () => {
+  let app: FastifyInstance;
+
+  const registryResourceMetadataFile = process.env.FS_REGISTRY_RESOURCE_METADATA_PATH!;
+  const gatewayResourceMetadataFile = process.env.FS_RESOURCE_METADATA_PATH!;
+
+  const registryResourceFile = process.env.FS_REGISTRY_RESOURCE_REPOSITORY_PATH!;
+  const gatewayResourceFile = process.env.FS_RESOURCE_REPOSITORY_PATH!;
+
+  const policyAttachmentsFolderPath = process.env.FS_REPOSITORY_POLICY_ATTACHMENTS_FOLDER_PATH!;
+
+  const registryMetadata: ResourcesMetadata = {
+    checksum: 'e3947dcecqda3ce6a6b29718f41c09b1',
+    summary: {
+      schemas: 8,
+      upstreams: 2,
+      upstreamClientCredentials: 1,
+      policyAttachments: 4,
+      policies: 19,
+      remoteSchemas: 11,
+      basePolicy: 1,
+      introspectionQueryPolicy: 1,
+    },
+  };
+
+  const gatewayMetadata: ResourcesMetadata = {
+    checksum: '505bb47e6ffq700792746223e51f49d1',
+    summary: {
+      schemas: 8,
+      upstreams: 2,
+      upstreamClientCredentials: 1,
+      policyAttachments: 4,
+      policies: 19,
+      remoteSchemas: 11,
+      basePolicy: 1,
+      introspectionQueryPolicy: 1,
+      pluginsData: 1,
+    },
+    plugins: [
+      {
+        name: 'an-awesome-plugin',
+        version: '0.1.15',
+      },
+    ],
+  };
+
+  const p1Metadata: ResourceMetadata = { name: 'p1_name', namespace: 'p1_namespace' };
+  const p2Metadata: ResourceMetadata = { name: 'p2_name', namespace: 'p2_namespace' };
+  const resourceGroup: ResourceGroup = {
+    schemas: [],
+    upstreams: [],
+    upstreamClientCredentials: [],
+    policies: [
+      { metadata: p1Metadata, type: PolicyType.opa, code: '' },
+      { metadata: p2Metadata, type: PolicyType.opa, code: '' },
+    ],
+  };
+  const p1AttachmentPath = path.join(policyAttachmentsFolderPath, getCompiledFilename(p1Metadata));
+  const p2AttachmentPath = path.join(policyAttachmentsFolderPath, getCompiledFilename(p2Metadata));
+
+  beforeAll(async () => {
+    app = await createRegistry();
+
+    await fs.mkdir(policyAttachmentsFolderPath, { recursive: true });
+
+    await Promise.all([
+      fs.writeFile(registryResourceMetadataFile, JSON.stringify(registryMetadata)),
+      fs.writeFile(gatewayResourceMetadataFile, JSON.stringify(gatewayMetadata)),
+      fs.writeFile(registryResourceFile, JSON.stringify(resourceGroup)),
+      fs.writeFile(gatewayResourceFile, JSON.stringify(resourceGroup)),
+      fs.writeFile(p1AttachmentPath, ''),
+      fs.writeFile(p2AttachmentPath, ''),
+    ]);
+  });
+
+  afterAll(async () => {
+    await app.close();
+
+    await Promise.all([
+      fs.unlink(registryResourceMetadataFile),
+      fs.unlink(gatewayResourceMetadataFile),
+      fs.unlink(registryResourceFile),
+      fs.unlink(gatewayResourceFile),
+      fs.unlink(p1AttachmentPath).catch(() => {}),
+      fs.unlink(p2AttachmentPath).catch(() => {}),
+    ]);
+  });
+
+  it('Returns the gateway metadata info by default', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/status',
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()?.metadata).toEqual(gatewayMetadata);
+  });
+
+  it('Returns the registry metadata info when the registry query param is set to true', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/status',
+      query: { registry: 'true' },
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()?.metadata).toEqual(registryMetadata);
+  });
+
+  it('Returns an empty missingOpaPolicyAttachments array when all the attachments exist', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/status',
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()?.missingOpaPolicyAttachments).toEqual([]);
+  });
+
+  it('Returns an empty missingOpaPolicyAttachments array when all the attachments exist but there is also an extra attachment without a policy', async () => {
+    const extraAttachmentPath = path.join(policyAttachmentsFolderPath, 'extra-attachment.wasm');
+    await fs.writeFile(extraAttachmentPath, '');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/status',
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()?.missingOpaPolicyAttachments).toEqual([]);
+
+    await fs.unlink(extraAttachmentPath);
+  });
+
+  it('Returns the metadata of a policy that is missing an attachment in the missingOpaPolicyAttachments array', async () => {
+    await fs.unlink(p1AttachmentPath);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/status',
+    });
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()?.missingOpaPolicyAttachments).toEqual([p1Metadata]);
+  });
+});


### PR DESCRIPTION
- Added the status endpoint to registry that returns the metadata file for the resource group and validates that policy attachments exist for all opa policies, returning an array of the policies that have missing attachments

- Fixed a bug in anonymous strategy authentication that included querystring as a part of the path