### PR TITLE
add option for using a keep-alive timeout

### DIFF
--- a/services/src/gateway.ts
+++ b/services/src/gateway.ts
@@ -56,6 +56,8 @@ export async function createServer() {
     reply.status(200).send('OK');
   });
 
+  app.server.keepAliveTimeout = config.keepAliveTimeout || app.server.keepAliveTimeout;
+
   sLogger.info('Stitch gateway is ready to start');
   return app;
 }

--- a/services/src/modules/config.ts
+++ b/services/src/modules/config.ts
@@ -13,6 +13,7 @@ const envVarExt = envVar.from(process.env, {
 export const nodeEnv = envVarExt.get('NODE_ENV').default('development').asString();
 
 export const httpPort = envVarExt.get('PORT').default('8080').asIntPositive();
+export const keepAliveTimeout = envVarExt.get('KEEP_ALIVE_TIMEOUT').asIntPositive();
 
 // Logging
 export type ChildLoggersLevels = Record<string, LevelWithSilent>;


### PR DESCRIPTION
For our use case, we need to be able to set a different keepAliveTimeout for the stitch server. With this extra option as an environment variable, original functionality will not be affected unless the variable is set.